### PR TITLE
refactor: remove dead code

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -28,7 +28,7 @@ export default {
         uid: { type: String, required: true },
         wwElementState: { type: Object, required: true },
     },
-    emits: ['update:content:effect', 'trigger-event', 'update:sidepanel-content'],
+    emits: ['update:content:effect', 'trigger-event'],
     setup(props) {
         const { value: variableValue, setValue } = wwLib.wwVariable.useComponentVariable({
             uid: props.uid,
@@ -93,28 +93,6 @@ export default {
             }
         },
         /* wwEditor:start */
-        'content.options': {
-            immediate: true,
-            handler(options) {
-                const objectOptions = (options || []).filter(option => option && typeof option === 'object');
-                if (objectOptions[0]) {
-                    this.$emit('update:sidepanel-content', {
-                        path: 'itemsProperties',
-                        value: Object.keys(objectOptions[0]),
-                    });
-                } else {
-                    this.$emit('update:sidepanel-content', { path: 'itemsProperties', value: [] });
-                }
-            },
-        },
-        // 'wwEditorState.sidepanelContent.itemsProperties'(newProperties, oldProperties) {
-        //     if (_.isEqual(newProperties, oldProperties)) return;
-        //     if (this.wwEditorState.boundProps.options && newProperties && newProperties[0]) {
-        //         this.$emit('update:content:effect', { displayField: newProperties[0], valueField: newProperties[0] });
-        //     } else {
-        //         this.$emit('update:content:effect', { displayField: null, valueField: null });
-        //     }
-        // },
         'wwEditorState.boundProps.options'(isBind) {
             if (!isBind) this.$emit('update:content:effect', { displayField: null, valueField: null });
         },
@@ -155,9 +133,6 @@ export default {
             }
         },
         setMatchingLabel() {
-            /* wwEditor:start */
-            if (this.isEditing) return;
-            /* wwEditor:end */
             const match = this.options.find(item => item.value === this.variableValue);
             this.label = match ? match.name : '';
         },


### PR DESCRIPTION
J'ai retiré le code qui concernait la récup des propriétés d'une option, plus nécessaire avec le nouveau champs ObjectPropertyPath.